### PR TITLE
Add read and open timeout configurations

### DIFF
--- a/lib/clearsale/config.rb
+++ b/lib/clearsale/config.rb
@@ -3,7 +3,7 @@ require 'nori'
 
 module Clearsale
   class Config
-    cattr_accessor :logger, :log
+    cattr_accessor :logger, :log, :read_timeout, :open_timeout
 
     def self.logger
       @@logger ||= Logger.new(STDOUT)

--- a/lib/clearsale/connector.rb
+++ b/lib/clearsale/connector.rb
@@ -32,6 +32,8 @@ module Clearsale
       savon_options[:proxy]  = proxy if proxy
       savon_options[:log]    = Clearsale::Config.log
       savon_options[:logger] = Clearsale::Config.logger
+      savon_options[:read_timeout] = Clearsale::Config.read_timeout if Clearsale::Config.read_timeout.present?
+      savon_options[:open_timeout] = Clearsale::Config.open_timeout if Clearsale::Config.open_timeout.present?
 
       @client = Savon.client(savon_options)
     end


### PR DESCRIPTION
In order to close connections after a defined timeout, I added read and open timeout configurations to avoid prey connections.